### PR TITLE
Fix hex strings missing "0" on the result.

### DIFF
--- a/lib/CssColors/rgb.ex
+++ b/lib/CssColors/rgb.ex
@@ -51,7 +51,7 @@ defmodule CssColors.RGB do
 
     defp to_hex(value) when is_float(value), do:
       to_hex(round(value))
-    defp to_hex(value) when value < 10, do:
+    defp to_hex(value) when value < 16, do:
       "0" <> Integer.to_string(value, 16)
     defp to_hex(value) when is_integer(value), do:
       Integer.to_string(value, 16)


### PR DESCRIPTION
Fixes hexadecimal conversion to string when value is higher than 10 and lesser than 16. 

In the current code, that's what happens:
```
iex > CssColors.parse!("#B8860B") |> to_string()
"#B886B"
```

That's because the `to_hex` for "0B" is matching with the last definition, that does not append the "0" at the start of the string.