### PR TITLE
Remove unused assignments

### DIFF
--- a/lib/CssColors/rgb.ex
+++ b/lib/CssColors/rgb.ex
@@ -65,7 +65,7 @@ defmodule CssColors.RGB do
         max_color = Enum.max colors
         min_color = Enum.min colors
 
-        h = s = l = (max_color + min_color) / 2;
+        l = (max_color + min_color) / 2
 
         if max_color == min_color do
           {0.0, 0.0, l}


### PR DESCRIPTION
Hi there, this PR removes two warnings shown when compiling this package on 1.7 👍

```
==> css_colors
Compiling 5 files (.ex)
warning: variable "h" is unused
  lib/CssColors/rgb.ex:68

warning: variable "s" is unused
  lib/CssColors/rgb.ex:68
```